### PR TITLE
Clean up the arguments

### DIFF
--- a/cmd/tmpfs/tmpfs.go
+++ b/cmd/tmpfs/tmpfs.go
@@ -18,7 +18,6 @@ var (
 	network = flag.String("net", "tcp4", "Default network type")
 	netaddr = flag.String("addr", ":5641", "Network address")
 	debug   = flag.Int("debug", 0, "Print debug messages")
-	pkg     = flag.String("package", "", "tar.gz package to open")
 )
 
 // Constant error messages to match those found in the linux 9p source.
@@ -319,17 +318,25 @@ func newTmpfs(arch *tmpfs.Archive, opts ...protocol.ListenerOpt) (*protocol.List
 	return l, nil
 }
 
+var usage = func() {
+	fmt.Fprintf(flag.CommandLine.Output(), "Usage: tmpfs [options] <tarfile>\n")
+	flag.PrintDefaults()
+	os.Exit(1)
+}
+
 func main() {
+	flag.Usage = usage
 	flag.Parse()
 
-	if *pkg == "" {
+	a := flag.Args()
+	// TODO: serve more than one archive.
+	if len(a) != 1 {
 		flag.Usage()
-		os.Exit(1)
 	}
-
-	pkfFile, err := os.Open(*pkg)
+	pkg := a[0]
+	pkfFile, err := os.Open(pkg)
 	if err != nil {
-		log.Fatalf("Couldn't open package %v error %v", *pkg, err)
+		log.Fatal(err)
 	}
 	defer pkfFile.Close()
 


### PR DESCRIPTION
The pkg flag was not optional, which is kind of confusing.
Make it a required option.

Do a bit of tidying up of command handling and usage.

Much of the erro text was not needed; remove it. The error
in most cases has all you need.

So now it looks like:
rminnich@rminnich-MacBookPro:~/go/src/harvey-os.org/cmd/tmpfs$ ./tmpfs
Usage: tmpfs [options] <tarfile>
  -addr string
    	Network address (default ":5641")
  -debug int
    	Print debug messages
  -net string
    	Default network type (default "tcp4")
rminnich@rminnich-MacBookPro:~/go/src/harvey-os.org/cmd/tmpfs$ ./tmpfs abc
2020/07/28 20:09:45 open abc: no such file or directory
rminnich@rminnich-MacBookPro:~/go/src/harvey-os.org/cmd/tmpfs$

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>