### PR TITLE
Add support for using #s (i.e. /srv)

### DIFF
--- a/internal/tmpfs/archive.go
+++ b/internal/tmpfs/archive.go
@@ -235,14 +235,14 @@ func (a *Archive) DumpArchive() {
 }
 
 // ReadImage reads a compressed tar to produce a file hierarchy
-func ReadImage(r io.Reader) *Archive {
+func ReadImage(r io.Reader) (*Archive, error) {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer func() {
 		if err := gzr.Close(); err != nil {
-			log.Fatal(err)
+			log.Print(err)
 		}
 	}()
 
@@ -255,18 +255,18 @@ func ReadImage(r io.Reader) *Archive {
 			break // End of archive
 		}
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 
 		file := newFile(hdr, uint64(id), uint64(hdr.Size))
 		if _, err := io.ReadFull(tr, file.data); err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 
 		if err = fs.addFile(hdr.Name, file); err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 	}
 
-	return fs
+	return fs, nil
 }

--- a/pkg/ninep/protocol/protocol.go
+++ b/pkg/ninep/protocol/protocol.go
@@ -291,7 +291,7 @@ type RPCReply struct {
 
 /* rpc servers */
 type ClientOpt func(*Client) error
-type ListenerOpt func(*Listener) error
+type NetListenerOpt func(*NetListener) error
 type Tracer func(string, ...interface{})
 
 type NineServer interface {

--- a/pkg/ninep/protocol/types.go
+++ b/pkg/ninep/protocol/types.go
@@ -4,7 +4,6 @@
 
 package protocol
 
-
 // A File is defined by a QID. File Servers never see a FID.
 // There are two channels. The first is for normal requests.
 // The second is for Flushes. File server code always

--- a/pkg/sys/postpipe.go
+++ b/pkg/sys/postpipe.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Ninep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sys
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// PostPipe creates a pipe, posts one side of it
+// #s at 'n', and returns the other side.
+func PostPipe(n string) (int, error) {
+	var fd [2]int
+	err := syscall.Pipe(fd[:])
+
+	if err != nil {
+		return -1, err
+	}
+	// We could, possibly, use os.Args[0] save that the caller may have
+	// rewritten or even removed them.
+	if len(n) == 0 {
+		n = fmt.Sprintf("post.%d", os.Getpid())
+	}
+	n = filepath.Join("#s", n)
+	if err := ioutil.WriteFile(n, []byte(fmt.Sprintf("%d", fd[1])), 0644); err != nil {
+		return -1, err
+	}
+	return fd[0], nil
+}


### PR DESCRIPTION
On plan 9, servers like tmpfs should use #s, not tcp/ip sockets.

Add PostPipe, for posting a pipe; and modify the server so we can create
a server from a path.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>