### PR TITLE
Add cpio suport for tmpfs; allow anything to be compressed; support f…

### DIFF
--- a/cmd/tmpfs/tmpfs_test.go
+++ b/cmd/tmpfs/tmpfs_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"fmt"
 	"log"
 	"testing"
@@ -21,14 +20,7 @@ func print(f string, args ...interface{}) {
 func createTestImage(t *testing.T, base int) *bytes.Buffer {
 	var buf bytes.Buffer
 
-	gztw := gzip.NewWriter(&buf)
-	defer func() {
-		if err := gztw.Close(); err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	tw := tar.NewWriter(gztw)
+	tw := tar.NewWriter(&buf)
 	defer func() {
 		if err := tw.Close(); err != nil {
 			log.Fatal(err)
@@ -68,7 +60,7 @@ func createTestImage(t *testing.T, base int) *bytes.Buffer {
 
 func TestReadImage(t *testing.T) {
 	tmpfs.Debug = t.Logf
-	_, err := tmpfs.ReadImage(createTestImage(t, 0))
+	_, err := tmpfs.ReadImageTar(createTestImage(t, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +68,7 @@ func TestReadImage(t *testing.T) {
 
 func TestReadImageBig(t *testing.T) {
 	tmpfs.Debug = t.Logf
-	_, err := tmpfs.ReadImage(createTestImage(t, 1048576))
+	_, err := tmpfs.ReadImageTar(createTestImage(t, 1048576))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module harvey-os.org
 
 go 1.14
+
+require (
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible
+	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible h1:vRAKYyEfhZV7SDTcaE3Cuop7tjDMOrapnBb59wVCcyE=
+github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/ninep/tmpfs/archive_test.go
+++ b/ninep/tmpfs/archive_test.go
@@ -3,7 +3,6 @@ package tmpfs
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"log"
 	"os"
 	"strings"
@@ -14,14 +13,7 @@ import (
 func createTestImage() *bytes.Buffer {
 	var buf bytes.Buffer
 
-	gztw := gzip.NewWriter(&buf)
-	defer func() {
-		if err := gztw.Close(); err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	tw := tar.NewWriter(gztw)
+	tw := tar.NewWriter(&buf)
 	defer func() {
 		if err := tw.Close(); err != nil {
 			log.Fatal(err)
@@ -65,7 +57,7 @@ func createTestImage() *bytes.Buffer {
 }
 
 func TestReadArchive(t *testing.T) {
-	arch, err := ReadImage(createTestImage())
+	arch, err := ReadImageTar(createTestImage())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
…ile type switch

cpio support now works.

More importantly, gzip compressed cpio archives work.

plan 9 initramfs does not support files with '.' in them, so we allow
the file type extension in the switches and it defaults to cpio.

The last mile is the symlinks; that's next.

Test on real harvey. Also includes minor fixup --> path instead of
filepath.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>
Signed-off-by: Ronald G Minnich <rminnich@gmail.com>