### PR TITLE
centre: tool for supporting harvey DHCP, TFTP, HTTP booting

### DIFF
--- a/cmd/centre/main.go
+++ b/cmd/centre/main.go
@@ -1,0 +1,293 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// centre is used to support one or more of DHCP, TFTP, and HTTP services
+// on harvey networks.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"net"
+	"net/http"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/dhcpv4/server4"
+	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/insomniacslk/dhcp/dhcpv6/server6"
+	"harvey-os.org/ninep/protocol"
+	"harvey-os.org/ninep/ufs"
+	"pack.ag/tftp"
+)
+
+var (
+	// TODO: get info from centre ipv4
+	inf = flag.String("i", "eth0", "Interface to serve DHCPv4 on")
+
+	// DHCPv4-specific
+	ipv4         = flag.Bool("4", true, "IPv4 DHCP server")
+	rootpath     = flag.String("rootpath", "", "RootPath option to serve via DHCPv4")
+	bootfilename = flag.String("bootfilename", "pxelinux.0", "Boot file to serve via DHCPv4")
+
+	// DHCPv6-specific
+	ipv6           = flag.Bool("6", false, "DHCPv6 server")
+	v6Bootfilename = flag.String("v6-bootfilename", "", "Boot file to serve via DHCPv6")
+
+	// File serving
+	tftpDir    = flag.String("tftp-dir", "", "Directory to serve over TFTP")
+	tftpPort   = flag.Int("tftp-port", 69, "Port to serve TFTP on")
+	httpDir    = flag.String("http-dir", "", "Directory to serve over HTTP")
+	httpPort   = flag.Int("http-port", 80, "Port to serve HTTP on")
+	ninepDir   = flag.String("ninep-dir", "", "Directory to serve over 9p")
+	ninepAddr  = flag.String("ninep-addr", ":5640", "addr to serve 9p on")
+	ninepDebug = flag.Int("ninep-debug", 0, "Debug level for ninep -- for now, only non-zero matters")
+)
+
+type dserver4 struct {
+	mac          net.HardwareAddr
+	yourIP       net.IP
+	submask      net.IPMask
+	self         net.IP
+	bootfilename string
+	rootpath     string
+}
+
+func (s *dserver4) dhcpHandler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4) {
+	log.Printf("Handling request %v for peer %v", m, peer)
+
+	var replyType dhcpv4.MessageType
+	switch mt := m.MessageType(); mt {
+	case dhcpv4.MessageTypeDiscover:
+		replyType = dhcpv4.MessageTypeOffer
+	case dhcpv4.MessageTypeRequest:
+		replyType = dhcpv4.MessageTypeAck
+	default:
+		log.Printf("Can't handle type %v", mt)
+		return
+	}
+
+	i, err := net.LookupIP(fmt.Sprintf("u%s", m.ClientHWAddr))
+	if err != nil {
+		log.Printf("Not responding to DHCP request for mac %s", m.ClientHWAddr)
+		log.Printf("You can create a host entry of the form 'a.b.c.d [names] u%s' 'ip6addr [names] u%s'if you wish", m.ClientHWAddr, m.ClientHWAddr)
+		return
+	}
+
+	// Since this is dserver4, we force it to be an ip4 address.
+	ip := i[0].To4()
+	reply, err := dhcpv4.NewReplyFromRequest(m,
+		dhcpv4.WithMessageType(replyType),
+		dhcpv4.WithServerIP(s.self),
+		dhcpv4.WithRouter(s.self),
+		dhcpv4.WithNetmask(s.submask),
+		dhcpv4.WithYourIP(ip),
+		// RFC 2131, Section 4.3.1. Server Identifier: MUST
+		dhcpv4.WithOption(dhcpv4.OptServerIdentifier(s.self)),
+		// RFC 2131, Section 4.3.1. IP lease time: MUST
+		dhcpv4.WithOption(dhcpv4.OptIPAddressLeaseTime(dhcpv4.MaxLeaseTime)),
+	)
+	// RFC 6842, MUST include Client Identifier if client specified one.
+	if val := m.Options.Get(dhcpv4.OptionClientIdentifier); len(val) > 0 {
+		reply.UpdateOption(dhcpv4.OptGeneric(dhcpv4.OptionClientIdentifier, val))
+	}
+	if len(s.bootfilename) > 0 {
+		reply.BootFileName = s.bootfilename
+	}
+	if len(s.rootpath) > 0 {
+		reply.UpdateOption(dhcpv4.OptRootPath(s.rootpath))
+	}
+	if err != nil {
+		log.Printf("Could not create reply for %v: %v", m, err)
+		return
+	}
+
+	// Experimentally determined. You can't just blindly send a broadcast packet
+	// with the broadcast address. You can, however, send a broadcast packet
+	// to a subnet for an interface. That actually makes some sense.
+	// This fixes the observed problem that OSX just swallows these
+	// packets if the peer is 255.255.255.255.
+	// I chose this way of doing it instead of files with build constraints
+	// because this is not that expensive and it's just a tiny bit easier to
+	// follow IMHO.
+	if runtime.GOOS == "darwin" {
+		p := &net.UDPAddr{IP: s.yourIP.Mask(s.submask), Port: 68}
+		log.Printf("Changing %v to %v", peer, p)
+		peer = p
+	}
+
+	log.Printf("Sending %v to %v", reply.Summary(), peer)
+	if _, err := conn.WriteTo(reply.ToBytes(), peer); err != nil {
+		log.Printf("Could not write %v: %v", reply, err)
+	}
+}
+
+type dserver6 struct {
+	mac         net.HardwareAddr
+	yourIP      net.IP
+	bootfileurl string
+}
+
+func (s *dserver6) dhcpHandler(conn net.PacketConn, peer net.Addr, m dhcpv6.DHCPv6) {
+	log.Printf("Handling DHCPv6 request %v sent by %v", m.Summary(), peer.String())
+
+	msg, err := m.GetInnerMessage()
+	if err != nil {
+		log.Printf("Could not find unpacked message: %v", err)
+		return
+	}
+
+	if msg.MessageType != dhcpv6.MessageTypeSolicit {
+		log.Printf("Only accept SOLICIT message type, this is a %s", msg.MessageType)
+		return
+	}
+	if msg.GetOneOption(dhcpv6.OptionRapidCommit) == nil {
+		log.Printf("Only accept requests with rapid commit option.")
+		return
+	}
+	if mac, err := dhcpv6.ExtractMAC(msg); err != nil {
+		log.Printf("No MAC address in request: %v", err)
+		return
+	} else if s.mac != nil && !bytes.Equal(s.mac, mac) {
+		log.Printf("MAC address %s doesn't match expected MAC %s", mac, s.mac)
+		return
+	}
+
+	// From RFC 3315, section 17.1.4, If the client includes a Rapid Commit
+	// option in the Solicit message, it will expect a Reply message that
+	// includes a Rapid Commit option in response.
+	reply, err := dhcpv6.NewReplyFromMessage(msg)
+	if err != nil {
+		log.Printf("Failed to create reply for %v: %v", m, err)
+		return
+	}
+
+	iana := msg.Options.OneIANA()
+	if iana != nil {
+		iana.Options.Update(&dhcpv6.OptIAAddress{
+			IPv6Addr:          s.yourIP,
+			PreferredLifetime: math.MaxUint32 * time.Second,
+			ValidLifetime:     math.MaxUint32 * time.Second,
+		})
+		reply.AddOption(iana)
+	}
+	if len(s.bootfileurl) > 0 {
+		reply.Options.Add(dhcpv6.OptBootFileURL(s.bootfileurl))
+	}
+
+	if _, err := conn.WriteTo(reply.ToBytes(), peer); err != nil {
+		log.Printf("Failed to send response %v: %v", reply, err)
+		return
+	}
+
+	log.Printf("DHCPv6 request successfully handled, reply: %v", reply.Summary())
+}
+
+func main() {
+	flag.Parse()
+
+	var wg sync.WaitGroup
+	if len(*tftpDir) != 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			server, err := tftp.NewServer(fmt.Sprintf(":%d", *tftpPort))
+			if err != nil {
+				log.Fatalf("Could not start TFTP server: %v", err)
+			}
+
+			log.Println("starting file server")
+			server.ReadHandler(tftp.FileServer(*tftpDir))
+			log.Fatal(server.ListenAndServe())
+		}()
+	}
+	if len(*httpDir) != 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			http.Handle("/", http.FileServer(http.Dir(*httpDir)))
+			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *httpPort), nil))
+		}()
+	}
+
+	centre, err := net.LookupIP("centre")
+	if err != nil {
+		log.Printf("No centre entry found via LookupIP: not serving DHCP")
+	} else if *ipv4 {
+		ip := centre[0].To4()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s := &dserver4{
+				self:         ip,
+				bootfilename: *bootfilename,
+				rootpath:     *rootpath,
+			}
+
+			laddr := &net.UDPAddr{Port: dhcpv4.ServerPort}
+			server, err := server4.NewServer(*inf, laddr, s.dhcpHandler)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if err := server.Serve(); err != nil {
+				log.Fatal(err)
+			}
+		}()
+	}
+
+	// not yet.
+	if false && *ipv6 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			s := &dserver6{
+				bootfileurl: *v6Bootfilename,
+			}
+			laddr := &net.UDPAddr{
+				IP:   net.IPv6unspecified,
+				Port: dhcpv6.DefaultServerPort,
+			}
+			server, err := server6.NewServer("eth0", laddr, s.dhcpHandler)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			log.Println("starting dhcpv6 server")
+			if err := server.Serve(); err != nil {
+				log.Fatal(err)
+			}
+		}()
+	}
+
+	// TODO: serve on ip6
+	if len(*ninepDir) != 0 {
+		ln, err := net.Listen("tcp4", *ninepAddr)
+		if err != nil {
+			log.Fatalf("Listen failed: %v", err)
+		}
+
+		ufslistener, err := ufs.NewUFS(*ninepDir, *ninepDebug, func(l *protocol.NetListener) error {
+			l.Trace = nil
+			if *ninepDebug > 1 {
+				l.Trace = log.Printf
+			}
+			return nil
+		})
+
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := ufslistener.Serve(ln); err != nil {
+			log.Fatal(err)
+		}
+
+	}
+	wg.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.14
 
 require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/insomniacslk/dhcp v0.0.0-20200814125043-2e1bf785d039
 	github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible
 	github.com/ulikunitz/xz v0.5.8
 	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
 	golang.org/x/tools v0.0.0-20200811215021-48a8ffc5b207 // indirect
+	pack.ag/tftp v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/insomniacslk/dhcp v0.0.0-20200814125043-2e1bf785d039 h1:0/zNUrLwk+KKke+36rq6HczOeXUNjJ8gI5fRAAJxDTY=
+github.com/insomniacslk/dhcp v0.0.0-20200814125043-2e1bf785d039/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
 github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible h1:vRAKYyEfhZV7SDTcaE3Cuop7tjDMOrapnBb59wVCcyE=
 github.com/u-root/u-root v6.0.1-0.20200728234108-3441aaa6cf0c+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
@@ -12,6 +14,7 @@ golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -28,3 +31,5 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+pack.ag/tftp v1.0.0 h1:q7iP8mKRtqTAWfxbQ4XY5/flZ5JmuThvrEmHPn8cN9A=
+pack.ag/tftp v1.0.0/go.mod h1:N1Pyo5YG+K90XHoR2vfLPhpRuE8ziqbgMn/r/SghZas=


### PR DESCRIPTION
Centre is intended to be one stop shopping for booting harvey nodes.
It can host DHCP, TFTP, HTTP, and 9p services.
The services are enabled individually.

Centre is configured for IP4 for now, and IP6, soon.

Unlike other systems where config files are scattered all over the place,
Centre can use, e.g., /etc/hosts to hold MAC to IP mappings. However, centre uses
golang host name lookup function, so the host mappings can be anywhere that is used
for hostname to IP mapping.

On Plan 9, for example, the would typically by in /lib/ndb/local, which already
has support for holding MAC and IP assocations.

No special file formats are needed. Users will need the ability to
edit /etc/hosts; but if users are running any kind of pxe or dhcp server,
you've got that already.

Centre need not enable DHCP. At start it looks up the hostname centre and, if
it is found, it will serve DHCP but only for hosts with entries locatable
with net.LookupIP.

When centre receives a request in the dserver4 loop, it will use the
net.LookupIP for a hostname  of the form: 'uMAC', where mac is the stringified
version of net.HardwareAddr, and u is a single-leter prefix to make it a hostname,
not a number. LookupIP returns a []net.IP. The code
uses the 1st element, converted to an ip4 with To4(), as the IP address.

If the lookup fails, centre prints an error message of the form:

2020/07/13 13:55:08 Not responding to DHCP request for mac 00:07:32:4c:25:36
2020/07/13 13:55:08 You can create a host entry of the form 'a.b.c.d [names] u00:07:32:4c:25:36' 'ip6addr [names] u00:07:32:4c:25:36'if you wish

which can be used to create a new hosts file entry.

The lookup does not choose to use /etc/hosts; although the current use is to add mappings to /etc/hosts, they can
be added to any source that is used by net.LookupIP. n

The lookup is stateless; centre does not cache, but rather does a new lookup each time, so that
should the host database, the new information can be used.

Example: one might have a network of several Atomic PIs. One can bring them up one at a time, and look
for messages of the form:
2020/07/13 13:55:08 Not responding to DHCP request for mac 00:07:32:4c:25:36
2020/07/13 13:55:08 You can create a host entry of the form 'a.b.c.d [names] u00:07:32:4c:25:36' 'ip6addr [names] u00:07:32:4c:25:36'if you wish

At that point, one might add this line to /etc/hosts:
192.168.0.4 api3 u00:07:32:4c:04:e6

On the next dhcp request, api3 will be provided with an ip.

This approach has many benefits: the file format is simple; leases need never expire; and, most important, once one assigns
a MAC to IP mapping, it is available for all other programs (e.g. cpu), which has proven very handy in practice.

On a recent experience setting up a small network of atomic pis, the task was accomplished with far less effort, and in
far less time, than was possible with isc-dhcpd and its companion tools.

My current /etc/hosts looks like this:

192.168.0.1 centre
192.168.0.2 up
192.168.0.3 api2 u00:07:32:4b:f9:f3
192.168.0.4 api3 u00:07:32:4c:04:e6
192.168.0.5 api4 u00:07:32:4c:25:36
192.168.0.6 rome uc8:b3:73:1f:44:55
192.168.0.7 a apu2 u00:0d:b9:49:0f:04
192.168.0.8 z zero u00:00:00:00:00:00
192.168.0.239 router

Note that zero was needed for a system that came up with an all-zeros MAC.

centre has options for enabling TFTP, HTTP, and a default host name.

For booting on one Harvey network, we just do this:
centre -i enp2s0f0 -bootfilename harvey.32bit

and that is enough. No other directories such as pxelinux.0, or files, or changes
in /etc, are needed.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>