### PR TITLE
decompress is a simple cmd to decompress lzma files, currently to stdout

### DIFF
--- a/cmd/decompress/main.go
+++ b/cmd/decompress/main.go
@@ -1,0 +1,59 @@
+// decompress is a tool for decompressing compressed files
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/ulikunitz/xz/lzma"
+)
+
+var (
+	usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: decompress [file]\n")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+)
+
+func decompress(infile *os.File, outfile *os.File) error {
+	r, err := lzma.NewReader(infile)
+	if err != nil {
+		return fmt.Errorf("couldn't open lzma file: %w", err)
+	}
+
+	_, err = io.Copy(outfile, r)
+	if err != nil {
+		return fmt.Errorf("couldn't copy lzma file: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+
+	filepaths := flag.Args()
+	if len(filepaths) == 0 {
+		// Decompress from stdin
+		decompress(os.Stdin, os.Stdout)
+	} else {
+		// Decompress files
+		if len(filepaths) > 1 {
+			usage()
+		}
+
+		filepath := filepaths[0]
+		file, err := os.Open(filepath)
+		if err != nil {
+			log.Fatalf("couldn't decompress file %v error %v", filepath, err.Error())
+		}
+		decompress(file, os.Stdout)
+		file.Close()
+	}
+}

--- a/cmd/decompress/main.go
+++ b/cmd/decompress/main.go
@@ -1,5 +1,4 @@
 // decompress is a tool for decompressing compressed files
-
 package main
 
 import (
@@ -20,7 +19,7 @@ var (
 	}
 )
 
-func decompress(infile *os.File, outfile *os.File) error {
+func decompress(infile io.Reader, outfile io.Writer) error {
 	r, err := lzma.NewReader(infile)
 	if err != nil {
 		return fmt.Errorf("couldn't open lzma file: %w", err)

--- a/cmd/decompress/main.go
+++ b/cmd/decompress/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io"
@@ -20,7 +21,9 @@ var (
 )
 
 func decompress(infile io.Reader, outfile io.Writer) error {
-	r, err := lzma.NewReader(infile)
+	bufinfile := bufio.NewReader(infile)
+
+	r, err := lzma.NewReader(bufinfile)
 	if err != nil {
 		return fmt.Errorf("couldn't open lzma file: %w", err)
 	}


### PR DESCRIPTION
Works on linux, seems to hang on harvey.  Possibly the semaphore bug?

To test:
 decompress < xxx.cpio > xxx
or
 decompress xxx.cpio > xxx

Possible todos:
- Add support for multiple files
- Add support for different compression algorithms
- Add support for writing to files other than stdout

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>