### PR TITLE
centre: specify the default subnet mask in DHCP packets

### DIFF
--- a/cmd/centre/main.go
+++ b/cmd/centre/main.go
@@ -246,6 +246,7 @@ func main() {
 					self:         ip,
 					bootfilename: *bootfilename,
 					rootpath:     *rootpath,
+					submask:      ip.DefaultMask(),
 				}
 
 				laddr := &net.UDPAddr{Port: dhcpv4.ServerPort}


### PR DESCRIPTION
Without explicitly setting the subnet mask, netbooting fails and wireshark indicates an error in the packet.  This commit fixes that by using the default mask for the ip address.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>