### PR TITLE
centre: fix netboot on Thinkpad T440p

### DIFF
--- a/cmd/centre/main.go
+++ b/cmd/centre/main.go
@@ -94,19 +94,21 @@ func (s *dserver4) dhcpHandler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHC
 		dhcpv4.WithOption(dhcpv4.OptServerIdentifier(s.self)),
 		// RFC 2131, Section 4.3.1. IP lease time: MUST
 		dhcpv4.WithOption(dhcpv4.OptIPAddressLeaseTime(dhcpv4.MaxLeaseTime)),
-		dhcpv4.WithOption(dhcpv4.OptClassIdentifier("PXEClient")),
 	}
 	if *raspi {
-		// Add option 43, suboption 9 (PXE native boot menu) to allow Raspberry Pi to recognise the offer
-		modifiers = append(modifiers, dhcpv4.WithOption(dhcpv4.Option{
-			Code: dhcpv4.OptionVendorSpecificInformation,
-			Value: bsdp.VendorOptions{Options: dhcpv4.OptionsFromList(
-				// The dhcp package only seems to support Apple BSDP boot menu items,
-				// so we have to craft the option by hand.
-				// \x11 is the length of the 'Raspberry Pi Boot' string...
-				dhcpv4.OptGeneric(dhcpv4.GenericOptionCode(9), []byte("\000\000\x11Raspberry Pi Boot")),
-			)},
-		}))
+		modifiers = append(modifiers,
+			dhcpv4.WithOption(dhcpv4.OptClassIdentifier("PXEClient")),
+			// Add option 43, suboption 9 (PXE native boot menu) to allow Raspberry Pi to recognise the offer
+			dhcpv4.WithOption(dhcpv4.Option{
+				Code: dhcpv4.OptionVendorSpecificInformation,
+				Value: bsdp.VendorOptions{Options: dhcpv4.OptionsFromList(
+					// The dhcp package only seems to support Apple BSDP boot menu items,
+					// so we have to craft the option by hand.
+					// \x11 is the length of the 'Raspberry Pi Boot' string...
+					dhcpv4.OptGeneric(dhcpv4.GenericOptionCode(9), []byte("\000\000\x11Raspberry Pi Boot")),
+				)},
+			}),
+		)
 	}
 	reply, err := dhcpv4.NewReplyFromRequest(m, modifiers...)
 


### PR DESCRIPTION
Commit 6ae8a97c297096829a1fa83673dc793085af332b added
`OptClassIdentifer` (option 60) "PXEClient" to modifiers in order to
support Raspberry Pi.  However, this option also causes my Thinkpad
T440p to not netboot anymore.  To fix this, add the ClassIdentifer
option only if the `-raspi` flag is used.

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>