### PR TITLE
elf2c: fix int overflow

### DIFF
--- a/cmd/elf2c/elf2c.go
+++ b/cmd/elf2c/elf2c.go
@@ -46,13 +46,13 @@ var dry = flag.Bool("dryrun", true, "don't really do it")
 
 func gencode(w io.Writer, n, t string, m []byte, start, end uint64) {
 	fmt.Fprintf(os.Stderr, "Write %v %v start %v end %v\n", n, t, start, end)
-	fmt.Fprintf(w, "int %v_%v_start = %v;\n", n, t, start)
-	fmt.Fprintf(w, "int %v_%v_end = %v;\n", n, t, end)
-	fmt.Fprintf(w, "int %v_%v_len = %v;\n", n, t, end-start)
-	fmt.Fprintf(w, "uint8_t %v_%v_out[] = {\n", n, t)
+	fmt.Fprintf(w, "u64 %v_%v_start = %#x;\n", n, t, start)
+	fmt.Fprintf(w, "u64 %v_%v_end = %#x;\n", n, t, end)
+	fmt.Fprintf(w, "u64 %v_%v_len = %#x;\n", n, t, end-start)
+	fmt.Fprintf(w, "u8 %v_%v_out[] = {\n", n, t)
 	for i := uint64(start); i < end; i += 16 {
 		for j := uint64(0); i+j < end && j < 16; j++ {
-			fmt.Fprintf(w, "0x%02x, ", m[j+i])
+			fmt.Fprintf(w, "%#02x, ", m[j+i])
 		}
 		fmt.Fprintf(w, "\n")
 	}


### PR DESCRIPTION
Build was failing on my system with the following error (gcc 10.2.0).
Changing the type from `int` to `u64` fixes the error.

```
/bin/gcc -std=c11 -c -I /home/big/src/harvey/amd64/include -I /home/big/src/harvey/sys/include -I . -fpic -fno-stack-protector -O0 -static -mno-red-zone -ffreestanding -fno-builtin -DKERNDAc
In file included from main.c:16:
init.h:262448:23: error: integer constant is so large that it is unsigned [-Werror]
262448 | int init_data_start = 18446744073709551615;
       |                       ^~~~~~~~~~~~~~~~~~~~
init.h:262448:23: error: overflow in conversion from ‘__int128’ to ‘int’ changes value from ‘18446744073709551615’ to ‘-1’ [-Werror=overflow]
```

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>