### PR TITLE
Add the -hostfile flag to centre.

### DIFF
--- a/cmd/centre/main.go
+++ b/cmd/centre/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"flag"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -40,6 +42,7 @@ var (
 	raspi        = flag.Bool("raspi", false, "Configure to boot Raspberry Pi")
 	dnsServers   = flag.String("dns", "", "Comma-separated list of DNS servers for DHCPv4")
 	gateway      = flag.String("gw", "", "Optional gateway IP for DHCPv4")
+	hostFile     = flag.String("hostfile", "", "Optional additional hosts file for DHCPv4")
 
 	// DHCPv6-specific
 	ipv6           = flag.Bool("6", false, "DHCPv6 server")
@@ -63,6 +66,38 @@ type dserver4 struct {
 	bootfilename string
 	rootpath     string
 	dns          []net.IP
+	hostFile     string
+}
+
+// lookupIP looks up an IP address corresponding to the given address
+// for mac address, prefix a "u", e.g. "u00:11:22:33:44:55"
+func lookupIP(hostFile string, addr string) ([]net.IP, error) {
+	var err error
+	// First try the override
+	if hostFile != `` {
+		// Read the file and walk each line looking for a match.
+		// We do this so you can update the file without restarting the server
+		var f *os.File
+		if f, err = os.Open(hostFile); err != nil {
+			return nil, err
+		}
+		// We're going to be real simple-minded. We take each line to consist of
+		// one IP, followed by one or more whitespace-separated hostnames
+		scan := bufio.NewScanner(f)
+		for scan.Scan() {
+			fields := strings.Fields(scan.Text())
+			if len(fields) < 2 {
+				continue
+			}
+			for _, fld := range fields {
+				if strings.ToLower(fld) == strings.ToLower(addr) {
+					return []net.IP{net.ParseIP(fields[0])}, nil
+				}
+			}
+		}
+	}
+	// Now just do a regular lookup since we didn't find it in the override
+	return net.LookupIP(addr)
 }
 
 func (s *dserver4) dhcpHandler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4) {
@@ -79,7 +114,7 @@ func (s *dserver4) dhcpHandler(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHC
 		return
 	}
 
-	i, err := net.LookupIP(fmt.Sprintf("u%s", m.ClientHWAddr))
+	i, err := lookupIP(s.hostFile, fmt.Sprintf("u%s", m.ClientHWAddr))
 	if err != nil {
 		log.Printf("Not responding to DHCP request for mac %s", m.ClientHWAddr)
 		log.Printf("You can create a host entry of the form 'a.b.c.d [names] u%s' 'ip6addr [names] u%s'if you wish", m.ClientHWAddr, m.ClientHWAddr)
@@ -256,7 +291,7 @@ func main() {
 	}
 
 	if *inf != "" {
-		centre, err := net.LookupIP("centre")
+		centre, err := lookupIP(*hostFile, "centre")
 		if err != nil {
 			log.Printf("No centre entry found via LookupIP: not serving DHCP")
 		} else if *ipv4 {
@@ -270,6 +305,7 @@ func main() {
 					rootpath:     *rootpath,
 					submask:      ip.DefaultMask(),
 					dns:          dns,
+					hostFile:     *hostFile,
 				}
 
 				laddr := &net.UDPAddr{Port: dhcpv4.ServerPort}


### PR DESCRIPTION
This specifies an alternate hosts file, in /etc/hosts format, which is checked
first when resolving IPs for DHCPv4 and when checking centre's own IP.

Signed-off-by: John Floren <john@jfloren.net>