### PR TITLE
Fix dhcpServe to use *sync.WaitGroup

### DIFF
--- a/cmd/centre/main.go
+++ b/cmd/centre/main.go
@@ -120,7 +120,7 @@ func main() {
 	}
 
 	if *inf != "" {
-		if err := dhcpServe(*inf, dns, wg); err != nil {
+		if err := dhcpServe(*inf, dns, &wg); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmd/centre/main_linux.go
+++ b/cmd/centre/main_linux.go
@@ -212,7 +212,7 @@ func (s *dserver6) dhcpHandler(conn net.PacketConn, peer net.Addr, m dhcpv6.DHCP
 	log.Printf("DHCPv6 request successfully handled, reply: %v", reply.Summary())
 }
 
-func dhcpServe(inf string, dns []net.IP, wg sync.WaitGroup) error {
+func dhcpServe(inf string, dns []net.IP, wg *sync.WaitGroup) error {
 	centre, _, err := lookupIP(*hostFile, "centre")
 	var ip net.IP
 	if err != nil {

--- a/cmd/centre/main_other.go
+++ b/cmd/centre/main_other.go
@@ -18,6 +18,6 @@ import (
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-func dhcpServe(_ string, _ []net.IP, _ sync.WaitGroup) error {
+func dhcpServe(_ string, _ []net.IP, _ *sync.WaitGroup) error {
 	return fmt.Errorf("no DHCP service on %s", runtime.GOOS)
 }


### PR DESCRIPTION
In b21b151001d180e6067450330796eb21dbfca087,
Fix centre to build on Plan 9

I introduced a bug with the dhcpServer function, which took
a sync.WaitGroup by value.

Thanks to fgergo for the catch.

Tested on Linux, dhcp4 service working fine.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>