### PR TITLE
centre: print when serving HTTP

### DIFF
--- a/cmd/centre/main.go
+++ b/cmd/centre/main.go
@@ -106,6 +106,7 @@ func main() {
 		go func() {
 			defer wg.Done()
 			http.Handle("/", http.FileServer(http.Dir(*httpDir)))
+			log.Println("starting HTTP server")
 			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *httpPort), nil))
 		}()
 	}


### PR DESCRIPTION
Same as for the file server, give feedback that HTTP is being served.

Signed-off-by: Daniel Maslowski <info@orangecms.org>